### PR TITLE
Upgrade pip in CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,8 +9,9 @@ jobs:
       with:
         python-version: '3.8'
         architecture: x64
-    - run: pip install nox==2019.11.9
-    - run: pip install poetry==1.0.5
+    - run: python -m pip install --upgrade pip
+    - run: python -m pip install nox==2019.11.9
+    - run: python -m pip install poetry==1.0.5
     - run: nox --sessions tests-3.8 coverage
       env:
         CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,9 @@ jobs:
       with:
         python-version: '3.8'
         architecture: x64
-    - run: pip install nox==2019.11.9
-    - run: pip install poetry==1.0.5
+    - run: python -m pip install --upgrade pip  
+    - run: python -m pip install nox==2019.11.9
+    - run: python -m pip install poetry==1.0.5
     - run: nox
     - run: poetry build
     - run: poetry publish --username=__token__ --password=${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -12,7 +12,8 @@ jobs:
       with:
         python-version: '3.8'
         architecture: x64
-    - run: pip install poetry==1.0.5
+    - run: python -m pip install --upgrade pip  
+    - run: python -m pip install poetry==1.0.5
     - run: >-
         poetry version patch &&
         version=$(poetry version | awk '{print $2}') &&

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
-    - run: pip install nox==2019.11.9
-    - run: pip install poetry==1.0.5
+    - run: python -m pip install --upgrade pip  
+    - run: python -m pip install nox==2019.11.9
+    - run: python -m pip install poetry==1.0.5
     - run: nox


### PR DESCRIPTION
We must make sure we're using the latest pip version before initiating the CI or CD.
Currently, all the builds have the same warning 

```
WARNING: You are using pip version 20.2.4; however, version 20.3 is available.
You should consider upgrading via the '/opt/hostedtoolcache/Python/3.8.6/x64/bin/python -m pip install --upgrade pip' command.
```