### PR TITLE
Update noxfile.py

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -33,6 +33,7 @@ def install_with_constraints(session: Session, *args: str, **kwargs: Any) -> Non
             "export",
             "--dev",
             "--format=requirements.txt",
+            "--without-hashes",
             f"--output={requirements.name}",
             external=True,
         )


### PR DESCRIPTION
Hallo! 👋  I am a _huge_ fan of your tutorial, thank you for putting it together!

To get nox working, I had to include the argument `--without-hashes` along with the `poetry export` command. Otherwise I get errors. For example, running:

```sh
nox -s black
```

I get the error:

```text
ERROR: In --require-hashes mode, all requirements must have their versions pinned with ==. These do not:
    black from https://files.pythonhosted.org/packages/d2/16/a92c999103bee1236dd93f703f3522217fe00bd97bd50ae3699c2d91e320/black-21.9b0-py3-none-any.whl#sha256=380f1b5da05e5a1429225676655dddb96f5ae8c75bdf91e53d798871b902a115
```

I am a bit confused by the error, but if it seems reproducible maybe you'd like to include this change?

My setup:

```text
Poetry==1.1.10
nox==2021.10.1
Python==3.9.7
```

Thanks again!